### PR TITLE
Makes the drone internal storage much more user-friendly

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -60,6 +60,8 @@
 #define ui_alien_storage_l "CENTER-2:14,SOUTH:5"//alien
 #define ui_alien_storage_r "CENTER+1:18,SOUTH:5"//alien
 
+#define ui_drone_storage "CENTER-2:14,SOUTH:5"  //maintenance drones
+
 //Lower right, persistant menu
 #define ui_drop_throw "EAST-1:28,SOUTH+1:7"
 #define ui_pull_resist "EAST-2:26,SOUTH+1:7"

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -69,6 +69,15 @@
 	l_hand_hud_object = inv_box
 	adding += inv_box
 
+	inv_box = new /obj/screen/inventory()
+	inv_box.name = "internal storage"
+	inv_box.icon = ui_style
+	inv_box.icon_state = "suit_storage"
+	inv_box.screen_loc = ui_drone_storage
+	inv_box.slot_id = "drone_storage_slot"
+	inv_box.layer = 19
+	adding += inv_box
+
 	using = new /obj/screen/inventory()
 	using.name = "hand"
 	using.icon = ui_style


### PR DESCRIPTION
I made a ui button that is an alias for internal_storage. This is much more user-friendly.
(It also shows what's in it!!)
![scrnshot2](https://cloud.githubusercontent.com/assets/5211576/4263549/fd75173e-3bed-11e4-98e5-09a718d8be41.png)
